### PR TITLE
Improving stream handling

### DIFF
--- a/src/main/java/com/techshard/download/controller/DownloadController.java
+++ b/src/main/java/com/techshard/download/controller/DownloadController.java
@@ -48,7 +48,7 @@ public class DownloadController {
                         }
                         inputStream.close();
                     }
-                    zipOut.close();
+                    zipOut.finish();
                 } catch (final IOException e) {
                     logger.error("Exception while reading and streaming data {} ", e);
                 }

--- a/src/main/java/com/techshard/download/controller/DownloadController.java
+++ b/src/main/java/com/techshard/download/controller/DownloadController.java
@@ -42,6 +42,7 @@ public class DownloadController {
                                 zipOut.write(bytes, 0, length);
                             }
                         }
+                        zipOut.closeEntry();
                     }
                     zipOut.finish();
                 } catch (final IOException e) {

--- a/src/main/java/com/techshard/download/controller/DownloadController.java
+++ b/src/main/java/com/techshard/download/controller/DownloadController.java
@@ -33,15 +33,15 @@ public class DownloadController {
             if(directory.exists() && directory.isDirectory()) {
                 try {
                     for (final File file : directory.listFiles()) {
-                        final InputStream inputStream=new FileInputStream(file);
                         final ZipEntry zipEntry=new ZipEntry(file.getName());
                         zipOut.putNextEntry(zipEntry);
-                        byte[] bytes=new byte[1024];
-                        int length;
-                        while ((length=inputStream.read(bytes)) >= 0) {
-                            zipOut.write(bytes, 0, length);
+                        try (final InputStream inputStream = new FileInputStream(file)) {
+                            byte[] bytes = new byte[1024];
+                            int length;
+                            while ((length = inputStream.read(bytes)) >= 0) {
+                                zipOut.write(bytes, 0, length);
+                            }
                         }
-                        inputStream.close();
                     }
                     zipOut.finish();
                 } catch (final IOException e) {

--- a/src/main/java/com/techshard/download/controller/DownloadController.java
+++ b/src/main/java/com/techshard/download/controller/DownloadController.java
@@ -21,7 +21,7 @@ public class DownloadController {
 
     private final Logger logger = LoggerFactory.getLogger(DownloadController.class);
 
-    @GetMapping (value = "/download", produces = MediaType.APPLICATION_JSON_VALUE)
+    @GetMapping (value = "/download", produces = "application/zip")
     public ResponseEntity<StreamingResponseBody> download(final HttpServletResponse response) {
 
         response.setContentType("application/zip");

--- a/src/main/java/com/techshard/download/controller/DownloadController.java
+++ b/src/main/java/com/techshard/download/controller/DownloadController.java
@@ -22,18 +22,13 @@ public class DownloadController {
     private final Logger logger = LoggerFactory.getLogger(DownloadController.class);
 
     @GetMapping (value = "/download", produces = "application/zip")
-    public ResponseEntity<StreamingResponseBody> download(final HttpServletResponse response) {
-
-        response.setContentType("application/zip");
-        response.setHeader(
-                "Content-Disposition",
-                "attachment;filename=sample.zip");
+    public ResponseEntity<StreamingResponseBody> download() {
 
         StreamingResponseBody stream = out -> {
 
             final String home = System.getProperty("user.home");
             final File directory = new File(home + File.separator + "Documents" + File.separator + "sample");
-            final ZipOutputStream zipOut = new ZipOutputStream(response.getOutputStream());
+            final ZipOutputStream zipOut = new ZipOutputStream(out);
 
             if(directory.exists() && directory.isDirectory()) {
                 try {
@@ -55,6 +50,8 @@ public class DownloadController {
             }
         };
         logger.info("steaming response {} ", stream);
-        return new ResponseEntity(stream, HttpStatus.OK);
+        return ResponseEntity.ok()
+                .header("Content-Disposition", "attachment;filename=sample.zip")
+                .body(stream);
     }
 }


### PR DESCRIPTION
Hi, your code was of great help to me. Thank you!
In this PR I made some changes towards the stream handling that I hope can make the code even better.

**1)** The call to the ZipOutputStream's [close](https://docs.oracle.com/javase/8/docs/api/java/util/zip/ZipOutputStream.html#close--) method also closes the servlet stream, which is not recommend:

> You should never call close() method as it will immediately disconnect the client socket and their will be no point executing request further on server as the client request is already processed. Also it will trimmed out all the configured post filters and interceptors execution that may results in various error condition.
[Source](https://stackoverflow.com/questions/1159168/should-one-call-close-on-httpservletresponse-getoutputstream-getwriter)

Because of that, I changed it to the [finish](https://docs.oracle.com/javase/8/docs/api/java/util/zip/ZipOutputStream.html#finish--) method.

**2)** Beyond that, I added a call to the ZipOutputStream's [closeEntry](closeEntry), fixed the contet type in the GetMapping annotation and added a try-with-resource block for automatic closing the InputStream after its use. 